### PR TITLE
Fixed changeNetem when drop==1.0f (float precision issue)

### DIFF
--- a/need/TCAL/TC.c
+++ b/need/TCAL/TC.c
@@ -504,7 +504,8 @@ void TC_changeNetem(Destination *dest){
     struct rtattr *tail = NLMSG_TAIL(&req.n);
 
     struct tc_netem_qopt opt = { .limit = txqueuelen };
-    opt.loss = rint(dest->packetLossRate * UINT32_MAX);
+    //Funny thing here, 1.0f*UINT32_MAX > UINT32_MAX (float precision issue, we have to use double)
+    opt.loss = rint(((double)dest->packetLossRate) * UINT32_MAX);
     //Since we are updating the opt structure, we have to fill in latency and jitter as well
     // (distribution is not necessary however)
     opt.latency = tc_core_time2tick(dest->latency*(TIME_UNITS_PER_SEC/1000));


### PR DESCRIPTION
When changeNetem is called with drop == 1.0f this causes an overflow due to float imprecision when representing 1.0f*4294967295 

Problem is fixed by casting drop to a double in TC.c:TC_changeNetem
