### PR TITLE
Fix Linking and Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Or cite it:
 
 ### Other links
 
-+ [Exmaples](./examples/README.md) - list of example applications to test Kollaps.
++ [Examples](./examples/README.md) - list of example applications to test Kollaps.
 + [Installation](./docs/install.md) - step by step installation guide.
 + [Orchestrators](./docs/orchestrators.md) - container orchestrators supported in Kollaps.
 + [Videos](./docs/videos.md) - a collection of talks and tutorials.

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ export DOCKER_BUILDKIT=1
 docker build --rm -f dockerfiles/Kollaps -t kollaps:1.0 .
 docker build -f dockerfiles/DeploymentGenerator -t kollaps-deployment-generator:1.0 .
 ```
-Now you are ready to test [some applications](examples/).
+Now you are ready to test [some applications](../examples/).
 
 ### Installation from Source <a name="source">
 
@@ -40,4 +40,4 @@ This installs the following tools:
 - `ThunderstormTranslator` command, which lets you declare an experiment in a language with higher-level concepts which are then translated into XML topology descriptions.
 Note that the examples below assume both tools are in your PATH, which might require restarting your shell.
 
-The rest of the procedure to test applications is described [here](examples/).
+The rest of the procedure to test applications is described [here](../examples/).


### PR DESCRIPTION
Fix the Typo on the Start page
Fix linking in the Doc to examples 

Edit: Can be tested on my fork: https://github.com/Raycoms/Kollaps/blob/master/docs/install.md